### PR TITLE
Be compatible with `blt drupal:sync:files`

### DIFF
--- a/settings/default.local.settings.php
+++ b/settings/default.local.settings.php
@@ -147,7 +147,7 @@ $settings['skip_permissions_hardening'] = TRUE;
  */
 $settings['file_private_path'] = $dir . '/files-private/default';
 if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
+  $settings['file_public_path'] = "sites/$_acsf_site_name/files";
   // phpcs:ignore
   $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
 }


### PR DESCRIPTION
`blt drupal:sync:files` a.k.a `drush sync` does not do a full bootstrap, so it would not pick up the `$_acsf_site_name` set in blt.settings.php, it will always sync the files to the files folder of each site.


Steps to replicate the issue
----------

Run blt:sync:files, the files being synced to `site/site_name/files` folder.

Previous (bad) behavior, before applying PR
----------

Visit the front page, the blt.settings.php expects files to be in `sites/default/files/site_name` folder

Expected behavior, after applying PR and re-running test steps
-----------

blt.settings.php should follow default local multi-sites files location convention.